### PR TITLE
feat: on click of a card, Pokemon IDs are regenerated and Pokemons show

### DIFF
--- a/src/components/Gameboard/Card/index.tsx
+++ b/src/components/Gameboard/Card/index.tsx
@@ -16,7 +16,6 @@ const Card = ({ pokemon, onMouseDown }: Props) => {
       }}
       className={styles.card}
       aria-label={name}
-      data-pokemon-id={id}
     >
       <figure className={styles.pokemonImageWrapper}>
         <img src={imageUrl} alt={name} className={styles.pokemonImage} />

--- a/src/components/Gameboard/index.tsx
+++ b/src/components/Gameboard/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useAllPokemons } from "../../hooks/useAllPokemons";
 import Card from "./Card";
 import styles from "./Gameboard.module.css";
@@ -10,6 +11,7 @@ const getRandomPokemonIds = (
     Math.floor(Math.random() * maxId + 1);
 
   const ids = new Set<number>();
+
   let count = 0;
   while (count < totalIds) {
     let randomPokemonId: number = getRandomId(maxPokemonId);
@@ -25,12 +27,18 @@ const getRandomPokemonIds = (
 const Gameboard = () => {
   const TOTAL_POKEMON_IDS = 10;
   const MAX_POKEMON_ID = 150; // generation 1
+  const [pokemonIds, setPokemonIds] = useState<number[]>(() =>
+    getRandomPokemonIds(TOTAL_POKEMON_IDS, MAX_POKEMON_ID),
+  );
 
-  const pokemonIds = getRandomPokemonIds(TOTAL_POKEMON_IDS, MAX_POKEMON_ID);
   const { pokemons, error, isLoading } = useAllPokemons(pokemonIds);
 
   const handleMousedownOnCard = (pokemonId: number) => {
-    console.log("pokemonId:", pokemonId);
+    const newPokemonIds = getRandomPokemonIds(
+      TOTAL_POKEMON_IDS,
+      MAX_POKEMON_ID,
+    );
+    setPokemonIds(newPokemonIds);
   };
 
   return (


### PR DESCRIPTION
* on initial load of app, when the `<Gameboard />` component renders, that component's local state (`useState` hook), holding the array of Pokemon IDs, immediately generates a list of random Pokemon IDs for the given parameters (we use `getRandomPokemonIds` helper)
  * this then triggers the fetching in `useAllPokemons` hook, because `pokemonIds` are passed in as an argument, and is in the `useEffect` hook's dependency array
  * I've opted to use a hashset for `getRandomPokemonIds` in the `while` loop because I believe it's more performant than using an array (adding and searching from a hashset is O(1) time). But, I convert it back into an array when I `return` because it's easier to manipulate arrays (like using `.map` in the `useAllPokemons` hook, rather than having to do a `.forEach` or `for` loop and then returning the array at the end)
* when user clicks on any of the individual cards, the handler passed down from `<Gameboard />` parent component, as a prop, into `<Card />` component is triggered. This handler is called `handleMousedownOnCard`. Yes, I know that right now we're not using the Pokemon ID of the specific Pokemon card that got clicked, but we'll definitely need this later on when we implement game logic (need to track this to know if a Pokemon has been clicked this round)
* this handler then updates the state for Pokemon IDs, which then triggers a re-render, and updates the arg passed into `useAllPokemons()` hook, which then triggers `useEffect` within that hook as Pokemon IDs are in its dependency array, thereby fetching new Pokemon data from PokeAPI, and then displaying it on the screen

