### PR TITLE
feat: enable keyboard controls

### DIFF
--- a/src/components/Gameboard/Card/index.tsx
+++ b/src/components/Gameboard/Card/index.tsx
@@ -4,15 +4,22 @@ import styles from "./Card.module.css";
 interface Props {
   pokemon: Pokemon;
   onMouseDown: (pokemonId: number) => void;
+  onKeyDown: (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    pokemonId: number,
+  ) => void;
 }
 
-const Card = ({ pokemon, onMouseDown }: Props) => {
+const Card = ({ pokemon, onMouseDown, onKeyDown }: Props) => {
   const { id, name, imageUrl } = pokemon;
 
   return (
     <button
       onMouseDown={() => {
         onMouseDown(id);
+      }}
+      onKeyDown={(e) => {
+        onKeyDown(e, id);
       }}
       className={styles.card}
       aria-label={name}

--- a/src/components/Gameboard/index.tsx
+++ b/src/components/Gameboard/index.tsx
@@ -1,11 +1,11 @@
 import Card from "./Card";
 import type { Pokemon } from "../../App";
-import styles from "./Gameboard.module.css";
 import {
   ID_OF_LAST_POKEMON_IN_GENERATION_1,
   TOTAL_POKEMONS_DISPLAYED,
 } from "../../constants";
 import { getRandomPokemonIds } from "../../helpers";
+import styles from "./Gameboard.module.css";
 
 interface Props {
   pokemons: Pokemon[];
@@ -26,7 +26,7 @@ const Gameboard = ({
   setPokemonIdsSelectedThisRound,
   setIsGameOver,
 }: Props) => {
-  const handleMousedownOnCard = (pokemonId: number) => {
+  const selectPokemon = (pokemonId: number) => {
     if (pokemonIdsSelectedThisRound.has(pokemonId)) {
       setIsGameOver(true);
       return;
@@ -41,7 +41,16 @@ const Gameboard = ({
       TOTAL_POKEMONS_DISPLAYED,
       ID_OF_LAST_POKEMON_IN_GENERATION_1,
     );
+
     setDisplayedPokemonsIds(newDisplayedPokemonsIds);
+  };
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    pokemonId: number,
+  ) => {
+    if (!(event.key === "Enter")) return;
+    selectPokemon(pokemonId);
   };
 
   return (
@@ -51,7 +60,10 @@ const Gameboard = ({
           key={pokemon.id}
           pokemon={pokemon}
           onMouseDown={() => {
-            handleMousedownOnCard(pokemon.id);
+            selectPokemon(pokemon.id);
+          }}
+          onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
+            handleKeyDown(event, pokemon.id);
           }}
         />
       ))}


### PR DESCRIPTION
this intends to improve accessibility - fixes #24 (see Issue there to see explanation on why I'm doing this).

outline is shown like so when user starts to "tab":
<img width="2526" height="1003" alt="image" src="https://github.com/user-attachments/assets/f4570f3d-4bdd-44ad-87db-c68d1fb4358b" />

after focusing on a Card component (user can select the correct one using "Tab" key), user can press "Enter" key to select it. User can also select Buttons in the modals that show up. These were manually tested.